### PR TITLE
reproducible builds (Debian Bug report)

### DIFF
--- a/manmake/Makefile.am
+++ b/manmake/Makefile.am
@@ -21,7 +21,7 @@ hints: manripper removeduplicates $(REFSOURCES) $(REFPROGSOURCES) ref.book.txt r
 	rm -f hints.unsorted
 	for file in ref.book.txt $(REFSOURCES) refprog.book.txt $(REFPROGSOURCES); do \
 	./manripper $(srcdir)/"$$file" >> hints.unsorted ; done
-	sort -t ":" hints.unsorted > hints.sorted
+	LC_ALL=C sort -t ":" hints.unsorted > hints.sorted
 	./removeduplicates hints.sorted hints.singlesorted
 	echo "::::" > tail.txt
 	cat hints.singlesorted tail.txt > hints


### PR DESCRIPTION
There is a Debian Bug report:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=791845

> While working on the "reproducible builds" effort [1], we have noticed
> that yacas could not be built reproducibly.
> The hints file is sorted differently depending on the configured locale.
> 
> The attached patch fixes this by setting LC_ALL to C before sorting.
