### PR TITLE
Bugfix for C++17

### DIFF
--- a/cyacas/libyacas/include/yacas/string_utils.h
+++ b/cyacas/libyacas/include/yacas/string_utils.h
@@ -16,14 +16,14 @@ std::string stringify(const std::string& s)
 inline
 std::string& ltrim(std::string& s)
 {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int c) { return !std::isspace(c); }));
     return s;
 }
 
 inline
 std::string& rtrim(std::string& s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
     return s;
 }
 


### PR DESCRIPTION
Moving to C++17 (#258 ) is not complete, there are errors in cyacas\libyacas\include\yacas\string_utils.h.
According to cppreference, std::ptr_fun is deprecated since C++11 and discontinued since C++17. Similarly, std::not1 is deprecated since C++17.

See #259 