### PR TITLE
Fix Qt platform directory install in win64 build

### DIFF
--- a/cyacas/yacas-gui/CMakeLists.txt
+++ b/cyacas/yacas-gui/CMakeLists.txt
@@ -153,7 +153,7 @@ if (WIN32)
 
 
     install (DIRECTORY "${QT_DLL_DIR}/../plugins/bearer" DESTINATION bin)
-    install (DIRECTORY "${QT_DLL_DIR}/../plugins/platforms" DESTINATION bin FILES_MATCHING PATTERN "*.PDB" EXCLUDE)
+    install (DIRECTORY "${QT_DLL_DIR}/../plugins/platforms" DESTINATION bin FILES_MATCHING PATTERN "*.dll")
     install (DIRECTORY "${QT_DLL_DIR}/../plugins/imageformats" DESTINATION bin)
     install (DIRECTORY "${QT_DLL_DIR}/../plugins/iconengines" DESTINATION bin)
     install (DIRECTORY "${QT_DLL_DIR}/../plugins/position" DESTINATION bin)


### PR DESCRIPTION
better solution might be `install (DIRECTORY "${QT_DLL_DIR}/../plugins/platforms" DESTINATION bin FILES_MATCHING PATTERN "*.*" PATTERN "*.PDB" EXCLUDE)` but I'm not used to use this CMake option, just guessing.