### PR TITLE
test-yacas: Use simply `bash` instead of `/bin/bash`

### DIFF
--- a/tests/test-yacas
+++ b/tests/test-yacas
@@ -69,7 +69,7 @@ for scr in $SCRIPTS; do
 #		fi
     echo "Running $scr"
 	if [ -f $TESTFILE ]; then rm $TESTFILE ; fi
-    /bin/bash -c "time -p ($CMD $f || echo \"Error: exit status $?\") | tee $TESTFILE" \
+	    bash -c "time -p ($CMD $f || echo \"Error: exit status $?\") | tee $TESTFILE" \
 		2> $TIMEFILE \
 		|| (echo "Error -- User interrupt" > $TESTFILE)
 #	cat $TIMEFILE


### PR DESCRIPTION
It's not always available, for example in systems such as NixOS (#339).

Fixes #339.